### PR TITLE
구조정리, OAuth2 로그인/JWT 토큰/시큐리티 구현 완료, PetMapper 분리

### DIFF
--- a/SsedamPet_back/src/main/java/com/korit/ssedampet_back/config/oauth/OAuth2SuccessHandler.java
+++ b/SsedamPet_back/src/main/java/com/korit/ssedampet_back/config/oauth/OAuth2SuccessHandler.java
@@ -4,6 +4,7 @@ import com.korit.ssedampet_back.entity.User;
 import com.korit.ssedampet_back.jwt.JwtTokenProvider;
 import com.korit.ssedampet_back.mapper.OAuth2UserMapper;
 import com.korit.ssedampet_back.mapper.UserMapper;
+import com.korit.ssedampet_back.security.PrincipalUser;
 import com.korit.ssedampet_back.service.OAuth2Service;
 import com.korit.ssedampet_back.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,8 +23,6 @@ import java.util.Map;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserMapper userMapper;
-    private final OAuth2Service oAuth2Service;
     private final OAuth2UserMapper oAuth2UserMapper;
     private final UserService userService;
 
@@ -31,36 +30,46 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
 
-        // 1. 표준화된 DefaultOAuth2User로 캐스팅 (Map 표준화 방식을 썼을 때)
-        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
-        Map<String, Object> attributes = oauth2User.getAttributes();
+//        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        PrincipalUser principalUser = (PrincipalUser) authentication.getPrincipal();
+        Map<String, Object> attributes = principalUser.getAttributes();
 
-        // 2. 표준 키값으로 정보 추출
+        User user = principalUser.getUser();
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getUserId());
+
         String email = (String) attributes.get("email");
         String provider = (String) attributes.get("provider");
         String providerUserId = (String) attributes.get("providerUserId");
         String profileImgUrl = (String) attributes.get("profileImgUrl");
         String name = (String) attributes.get("name");
 
-        // 3. 기존 가입 여부 확인 (Join 쿼리 사용)
-        User existingUser = oAuth2UserMapper.findUserByOAuth2Info(provider, providerUserId);
+        System.out.println("provider = " + provider);
 
-        String accessToken;
-        String targetUrl;
+        boolean needAdditionalInfo = user.getPhone() == null || user.getUserBirth() == null;
 
-        if (existingUser == null) {
-            // 4. 신규 유저- 깡통 계정 생성 (이미지 포함)
-            User newUser = userService.registerUser(email, name, profileImgUrl, provider, providerUserId);
-            accessToken = jwtTokenProvider.createAccessToken(newUser);
+        String targetUrl = needAdditionalInfo
+                ? "http://localhost:5173/signup/details?accessToken=" + accessToken
+                : "http://localhost:5173/auth/oauth2/success?accessToken=" + accessToken;
 
-            // 추가 정보 입력 페이지로 리다이렉트 (이미지 URL도 같이 보냄)
-            targetUrl = "http://localhost:5173/signup/details?accessToken=" + accessToken
-                    + "&profileImg=" + profileImgUrl;
-        } else {
-            // 5. 기존 유저: 로그인 처리
-            accessToken = jwtTokenProvider.createAccessToken(existingUser);
-            targetUrl = "http://localhost:5173/auth/oauth2/success?accessToken=" + accessToken;
-        }
+//        // 기존 가입 여부 확인
+//        User existingUser = oAuth2UserMapper.findUserByOAuth2Info(provider, providerUserId);
+//        String targetUrl;
+//
+//        if (existingUser == null) {
+//            // 신규 유저- 깡통 계정 생성
+//            User newUser = userService.registerUser(email, name, profileImgUrl, provider, providerUserId);
+//            accessToken = jwtTokenProvider.createAccessToken(newUser);
+//
+//            // 추가 정보 입력 페이지로 리다이렉트 (이미지 URL도 같이 보냄)
+//            targetUrl = "http://localhost:5173/signup/details?accessToken=" + accessToken
+//                    + "&profileImg=" + profileImgUrl;
+//        } else {
+//            // 기존 유저: 로그인 처리
+//            accessToken = jwtTokenProvider.createAccessToken(existingUser);
+//            targetUrl = "http://localhost:5173/auth/oauth2/success?accessToken=" + accessToken;
+//        }
+
         System.out.println("발급된 서버 JWT 토큰: " + accessToken);
 
         response.sendRedirect(targetUrl);

--- a/SsedamPet_back/src/main/java/com/korit/ssedampet_back/jwt/JwtTokenProvider.java
+++ b/SsedamPet_back/src/main/java/com/korit/ssedampet_back/jwt/JwtTokenProvider.java
@@ -36,8 +36,22 @@ public class JwtTokenProvider {
                 .claim("userId", user.getUserId())   // 유저id 가 몇번인지
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
+    }
 
+    // 토큰 만들기 (userId만)
+    public String createAccessToken(int userId) {
+        Date now = new Date();
+        long expiredTime = now.getTime() + (1000L * 60L * 60L * 24L);  // 1일
+        Date expiredDate = new Date(expiredTime);
 
+        return Jwts.builder()
+                .subject("Server access token")
+                .issuer("ssedampet")
+                .issuedAt(now)
+                .expiration(expiredDate)
+                .claim("userId", userId)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
     }
 
     // validateToken - 토큰 검증

--- a/SsedamPet_back/src/main/java/com/korit/ssedampet_back/security/PrincipalUser.java
+++ b/SsedamPet_back/src/main/java/com/korit/ssedampet_back/security/PrincipalUser.java
@@ -21,7 +21,11 @@ public class PrincipalUser extends DefaultOAuth2User {
 
     public static PrincipalUser getAuthenticatedPrincipalUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        PrincipalUser prinicipalUser = (PrincipalUser) authentication.getPrincipal();
-        return prinicipalUser;
+        if (authentication == null) return null;
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof PrincipalUser pu) return pu;
+
+        return null;
     }
 }

--- a/SsedamPet_back/src/main/java/com/korit/ssedampet_back/service/UserService.java
+++ b/SsedamPet_back/src/main/java/com/korit/ssedampet_back/service/UserService.java
@@ -41,6 +41,9 @@ public class UserService {
                              String provider,
                              String providerUserId) {
 
+        // [수정] provider가 null로 넘어올 경우를 대비한 2중 방어
+        String finalProvider = (provider != null) ? provider.toUpperCase() : "GOOGLE";
+
         User user = User.builder()
                 .username(name)
                 .email(email)
@@ -50,13 +53,11 @@ public class UserService {
 
         userMapper.addUser(user);
 
-        oAuth2UserMapper.addOAuth2User(
-                OAuth2UserEntity.builder()
-                        .userId(user.getUserId())
-                        .provider(OAuth2UserEntity.Provider.valueOf(provider.toUpperCase()))
-                        .providerUserId(providerUserId)
-                        .build()
-        );
+        oAuth2UserMapper.addOAuth2User(OAuth2UserEntity.builder()
+                .userId(user.getUserId())
+                .provider(OAuth2UserEntity.Provider.valueOf(finalProvider)) // 안전하게 변환
+                .providerUserId(providerUserId)
+                .build());
 
         return user;
     }

--- a/SsedamPet_back/src/main/resources/mapper/oauth2_user_mapper.xml
+++ b/SsedamPet_back/src/main/resources/mapper/oauth2_user_mapper.xml
@@ -6,9 +6,9 @@
     <!-- OAuth2 유저 신규추가 -->
     <insert id="addOAuth2User">
         insert into
-        oauth2_user_tb
+            oauth2_user_tb(user_id, provider, provider_user_id, created_dt, updated_dt)
         values
-        (0, #{userId}, #{provider}, #{providerUserId}, NOW(), NOW())
+        (#{userId}, #{provider}, #{providerUserId}, NOW(), NOW())
     </insert>
 
     <!-- OAuth2 유저 조회 -->
@@ -25,7 +25,7 @@
     </select>
     <select id="findByProviderAndProviderUserId" resultType="com.korit.ssedampet_back.entity.OAuth2UserEntity">
         select
-            oauth2_user_id, -- DB 컬럼명
+            oauth2_user_id,
             user_id,
             provider,
             provider_user_id,


### PR DESCRIPTION
1. 프로젝트 구조 정리
Auth / User / Pet / OAuth2 책임 분리
DTO / Entity / Mapper 역할 재정비
소셜 로그인 이후 “추가 정보 입력 단계” 구조로 회원가입 플로우 분리
2. OAuth2 로그인 구현 완료
Google / Naver / Kakao OAuth2 로그인 연동
Provider별 사용자 정보 파싱 로직 구현
OAuth2 로그인 성공 시 사용자 식별 정보 추출 완료
3. OAuth2 사용자 관리 구조 개선
user_tb 와 oauth2_user_tb 테이블 분리
OAuth2 전용 Mapper (OAuth2UserMapper) 분리
provider + providerUserId 기반 사용자 매핑 구조 적용
기존 유저 / 신규 유저 분기 처리 로직 구현
4. JWT 기반 인증 시스템 구축
OAuth2 로그인 성공 시 JWT 토큰 발급 로직 구현
JWT 토큰 클레임에 userId 포함
Authorization 헤더(Bearer Token) 기반 인증 처리
5. Spring Security 설정 완료
JwtAuthenticationFilter 를 통한 인증 필터 체인 구성
OAuth2Login + JWT 인증 방식 병행 구성 완료
6. OAuth2 → JWT 인증 흐름 검증 완료
OAuth2 로그인 성공 후 JWT 토큰 정상 발급 확인
JWT 토큰으로 보호된 API 접근 테스트 완료
SecurityContext 에 인증 객체 정상 주입 확인
7. Pet 관련 로직 정리

Pet 등록 로직을 Service / Mapper 단위로 재정비
회원 추가 정보 입력 단계에서 반려동물 등록 연동
PetMapper 파라미터 타입 및 책임 정리

--기타 개선 사항
Mapper 메서드 수정
DTO 필드명 / Getter 불일치 문제 해결

트랜잭션 경계 정리 (회원 + OAuth2 매핑 + Pet 등록)